### PR TITLE
Fix: 404 "Gå bakåt"-knapp fungerar inte pga TagSanitizer

### DIFF
--- a/autoload/error-page.php
+++ b/autoload/error-page.php
@@ -55,3 +55,19 @@ add_action(
   },
   11,
 );
+
+/**
+ * Fix the "Go back" button on 404 pages.
+ *
+ * The ComponentLibrary TagSanitizer strips "javascript:" from href values for security,
+ * which breaks the history.go(-1) navigation. This filter converts the link to a button
+ * with an onclick handler instead.
+ */
+add_filter('ComponentLibrary/Component/Button/Data', function ($data) {
+    if (!empty($data['href']) && str_contains($data['href'], 'history.go')) {
+        $data['attributeList']['onclick'] = $data['href'];
+        $data['href'] = false;
+        $data['componentElement'] = 'button';
+    }
+    return $data;
+});


### PR DESCRIPTION
## Sammanfattning

- Lägger till filter som konverterar knappar med `history.go` i href till att använda `onclick` istället
- Löser problemet där TagSanitizer tar bort `javascript:` från href-värden

Closes #1

## Testplan

- [ ] Gå till en 404-sida
- [ ] Klicka på "Gå bakåt"-knappen
- [ ] Verifiera att webbläsaren går tillbaka till föregående sida

🤖 Generated with [Claude Code](https://claude.com/claude-code)