### PR TITLE
Fix: 404 pages returning 200 OK with frontpage in Multisite

### DIFF
--- a/autoload/error-page.php
+++ b/autoload/error-page.php
@@ -1,5 +1,20 @@
 <?php
 
+/**
+ * Disable verbose page rules in WordPress Multisite.
+ *
+ * Multisite enables use_verbose_page_rules by default, which causes non-existent
+ * pages to return 200 OK with frontpage content instead of 404. This happens because
+ * WordPress validates page existence before accepting rewrite matches, and when no
+ * page exists it falls back to the frontpage with empty query_vars.
+ *
+ * Requires rewrite flush after activation: wp rewrite flush or Settings → Permalinks → Save.
+ */
+add_action('init', function () {
+    global $wp_rewrite;
+    $wp_rewrite->use_verbose_page_rules = false;
+}, 1);
+
 function mx_get_custom_404_page() {
   static $custom_page;
   if (isset($custom_page)) {


### PR DESCRIPTION
## Summary

- Disables `use_verbose_page_rules` which WordPress Multisite enables by default
- Restores proper 404 handling for non-existent pages

## Test plan

- [ ] Visit a non-existent URL (e.g., `/this/page/does/not/exist`) and verify 404 is returned
- [ ] Visit valid pages and verify they still work (single and hierarchical)
- [ ] Flush rewrite rules after deployment (`wp rewrite flush`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)