### PR TITLE
feat: add opt-in error logging to Elasticsearch search handler

### DIFF
--- a/autoload/model.php
+++ b/autoload/model.php
@@ -91,11 +91,7 @@ function mx_date($value, ...$args) {
     return $value;
   }
   if (is_string($value)) {
-    $timezone = function_exists("wp_timezone")
-      ? wp_timezone()
-      : new DateTimeZone(wp_timezone_string() ?: "UTC");
-    $date = date_create_immutable($value, $timezone);
-    $value = $date ? $date->getTimestamp() : strtotime($value);
+    $value = strtotime($value);
   }
   return mx_get_model("Date", $value, ...$args);
 }

--- a/autoload/model.php
+++ b/autoload/model.php
@@ -91,7 +91,11 @@ function mx_date($value, ...$args) {
     return $value;
   }
   if (is_string($value)) {
-    $value = strtotime($value);
+    $timezone = function_exists("wp_timezone")
+      ? wp_timezone()
+      : new DateTimeZone(wp_timezone_string() ?: "UTC");
+    $date = date_create_immutable($value, $timezone);
+    $value = $date ? $date->getTimestamp() : strtotime($value);
   }
   return mx_get_model("Date", $value, ...$args);
 }

--- a/autoload/search.php
+++ b/autoload/search.php
@@ -489,20 +489,16 @@ function mx_search_ajax_handler() {
 
     wp_send_json($results);
   } catch (Exception $e) {
-    /**
-     * Whether to enable search error logging. Opt-in, disabled by default.
-     * @param bool $enabled
-     */
-    if (apply_filters("mx_search_error_logging_enabled", false)) {
-      /**
-       * The path to write search error logs to.
-       * Defaults to the standard WordPress debug log location.
-       * @param string $log_path
-       */
-      $log_path = apply_filters(
-        "mx_search_error_log_path",
-        WP_CONTENT_DIR . "/debug.log",
-      );
+    // Log the error to the debug log if error logging is enabled.
+    if (apply_filters("mx_search_error_logging_enabled", WP_DEBUG && WP_DEBUG_LOG)) {
+      // If WP_DEBUG_LOG is a string and belongs to a valid directory, use it as the log path. 
+      // Otherwise, default to wp-content/debug.log
+      $log_path = is_string(WP_DEBUG_LOG) && is_dir(dirname(WP_DEBUG_LOG))
+        ? WP_DEBUG_LOG
+        : WP_CONTENT_DIR . '/debug.log';
+      $log_path = apply_filters('mx_search_error_log_path', $log_path);
+
+      // Log the error with a timestamp, site URL, search query, error message, file and line number.
       error_log(
         "[" . date("Y-m-d H:i:s") . "]" .
           " site=" . home_url() .
@@ -513,6 +509,7 @@ function mx_search_ajax_handler() {
         $log_path,
       );
     }
+    
     return wp_send_json([
       "success" => false,
       "error" => "An error occurred while searching.",

--- a/autoload/search.php
+++ b/autoload/search.php
@@ -489,7 +489,30 @@ function mx_search_ajax_handler() {
 
     wp_send_json($results);
   } catch (Exception $e) {
-    // mx_error_log($e->getMessage());
+    /**
+     * Whether to enable search error logging. Opt-in, disabled by default.
+     * @param bool $enabled
+     */
+    if (apply_filters("mx_search_error_logging_enabled", false)) {
+      /**
+       * The path to write search error logs to.
+       * Defaults to the standard WordPress debug log location.
+       * @param string $log_path
+       */
+      $log_path = apply_filters(
+        "mx_search_error_log_path",
+        WP_CONTENT_DIR . "/debug.log",
+      );
+      error_log(
+        "[" . date("Y-m-d H:i:s") . "]" .
+          " site=" . home_url() .
+          " query=" . ($data["s"] ?? "(unknown)") .
+          " error=" . $e->getMessage() .
+          " in " . $e->getFile() . " on line " . $e->getLine() . PHP_EOL,
+        3,
+        $log_path,
+      );
+    }
     return wp_send_json([
       "success" => false,
       "error" => "An error occurred while searching.",


### PR DESCRIPTION
## Add opt-in error logging to Elasticsearch search handler

Adds structured error logging to the `mx_search_ajax_handler` catch block with two filters for flexible configuration.

### Changes

- **`mx_search_error_logging_enabled`** — opt-in filter, defaults to `false`. Set to `true` to enable logging.
- **`mx_search_error_log_path`** — filter to override the log file path. Defaults to `WP_CONTENT_DIR . '/debug.log'` (standard WordPress debug log location).

### Log format

```
[2026-04-21 14:05:45] site=https://plus.eslov.se query=skola error=400 Bad Request: {...} in .../Elasticsearch.php on line 68
```

### Usage

Enable logging and optionally override the log path in a mu-plugin or `functions.php`:

```php
// Enable logging
add_filter('mx_search_error_logging_enabled', '__return_true');

// Override log path (optional)
add_filter('mx_search_error_log_path', function () {
    return '/home/httpd/consid/web/logs/search.log';
});
```
