### PR TITLE
fix: parse job date strings in WordPress timezone

### DIFF
--- a/autoload/model.php
+++ b/autoload/model.php
@@ -91,7 +91,12 @@ function mx_date($value, ...$args) {
     return $value;
   }
   if (is_string($value)) {
-    $value = strtotime($value);
+    $timezone = function_exists("wp_timezone")
+      ? wp_timezone()
+      : new DateTimeZone(wp_timezone_string() ?: "UTC");
+
+    $date = date_create_immutable($value, $timezone);
+    $value = $date ? $date->getTimestamp() : strtotime($value);
   }
   return mx_get_model("Date", $value, ...$args);
 }


### PR DESCRIPTION
## Problem

Visma Recruit sends date strings without a timezone suffix (e.g.
`2026-04-12T23:59:00`). `mx_date()` passed these directly to `strtotime()`,
which interpreted them as UTC because the PHP runtime timezone is UTC.
The timestamp was then formatted by `wp_date()` in the site timezone
(`Europe/Stockholm`, UTC+1/+2), shifting the result by one to two hours.

## Impact

- Application deadlines displayed one calendar day too late. Deadlines are
  typically set to `23:59:00` on the last day, placing them right at the
  boundary between two calendar days. A shift of just one to two hours was
  enough to push the timestamp into the next day (e.g. a deadline of
  `2026-04-12T23:59:00` became `2026-04-13 01:59 CEST` after the UTC
  misinterpretation, displaying as `13 april` instead of `12 april`).
- The "days left" counter and expired/active state were calculated from the
  same shifted timestamp, so jobs could appear active or expired at the
  wrong time.

## Fix

`mx_date()` now uses `date_create_immutable()` with `wp_timezone()` to parse
offset-less strings as Stockholm local time before converting to a timestamp.
Strings that already carry an explicit offset or `Z` are unaffected.

**File changed:** `autoload/model.php`

```php
// Before
if (is_string($value)) {
    $value = strtotime($value);
}

// After
if (is_string($value)) {
    $timezone = function_exists("wp_timezone")
        ? wp_timezone()
        : new DateTimeZone(wp_timezone_string() ?: "UTC");
    $date = date_create_immutable($value, $timezone);
    $value = $date ? $date->getTimestamp() : strtotime($value);
}
```

---

## Appendix: supported input formats

`wp_timezone()` is only applied as a **fallback** when the string contains no
timezone information, matching the documented behaviour of
`date_create_immutable()`.

| Input string | How it is parsed |
|---|---|
| `2026-04-12T23:59:00` | No offset → interpreted as Stockholm local time via `wp_timezone()` |
| `2026-04-12T23:59:00+02:00` | Explicit CEST offset → used as-is |
| `2026-04-12T23:59:00+01:00` | Explicit CET offset → used as-is |
| `2026-04-12T23:59:00Z` | UTC (`Z`) → used as-is |