### PR TITLE
feat: override ElasticPress default shards and replicas via filters

### DIFF
--- a/autoload/elasticpress.php
+++ b/autoload/elasticpress.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Keep ElasticPress index settings in the site-specific MU plugin layer
+ * instead of the active theme, so search configuration survives theme changes.
+ */
+add_filter("ep_default_index_number_of_shards", function ($shards) {
+  return (int) apply_filters(
+    "mx_elasticpress_default_index_number_of_shards",
+    1,
+    $shards,
+  );
+});
+
+add_filter("ep_default_index_number_of_replicas", function ($replicas) {
+  return (int) apply_filters(
+    "mx_elasticpress_default_index_number_of_replicas",
+    0,
+    $replicas,
+  );
+});


### PR DESCRIPTION
## Fix ElasticPress yellow index status

ElasticPress defaults to requesting more shards and replicas than are
available on this single-node Elasticsearch cluster. This caused all
indices to remain in a **yellow** health state, since Elasticsearch
could not allocate the requested replicas.

### Changes

- Sets the default number of shards to `1` via the
  `ep_default_index_number_of_shards` filter.
- Sets the default number of replicas to `0` via the
  `ep_default_index_number_of_replicas` filter.
- Both values are overridable via the `mx_elasticpress_*` filters for
  environments that run a multi-node cluster.
- Configuration lives in the MU plugin layer so it survives theme
  changes.

### Why

A single-node Elasticsearch cluster cannot assign replica shards to a
different node — there is only one. With replicas > 0 the index stays
yellow indefinitely. Setting replicas to `0` and shards to `1` matches
the actual cluster topology and results in a **green** index status.