### PR TITLE
fix: resolve children/siblings in headless rest context

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Override the resolved model class.
 `apply_filters( 'mx/module_wrapper_attrs', array $attrs, array $args, string $postType, int $postId )`
 Add attributes to Modularity module wrappers.
 
+`apply_filters( 'mx/module/current_post', WP_Post|null $post, MxModule $module )`
+Override the post a module is rendered in the context of. Defaults to the
+global `$post`, which is empty outside the loop (e.g. REST requests).
+
 `apply_filters( 'mxui/debug_enabled', bool $enabled )` Enable MXUI debug output.
 
 ### Component Modifiers

--- a/README.sv.md
+++ b/README.sv.md
@@ -125,6 +125,10 @@ Ersätt den lösta modellklassen.
 `apply_filters( 'mx/module_wrapper_attrs', array $attrs, array $args, string $postType, int $postId )`
 Lägg till attribut på Modularity-modulwrappers.
 
+`apply_filters( 'mx/module/current_post', WP_Post|null $post, MxModule $module )`
+Ändra vilken post en modul renderas för. Standardvärdet är globala `$post`,
+som saknas utanför loopen (t.ex. vid REST-anrop).
+
 `apply_filters( 'mxui/debug_enabled', bool $enabled )` Aktivera
 MXUI-debugutskrift.
 

--- a/psr-4/Modularity/ModNavigation/ModNavigation.php
+++ b/psr-4/Modularity/ModNavigation/ModNavigation.php
@@ -121,18 +121,6 @@ class ModNavigation extends MxModule {
     return get_field($field, $this->ID, ...$args);
   }
 
-  /**
-   * Current page id: the constructor `post_id` arg (set in headless REST
-   * context), falling back to the global `$post`.
-   */
-  protected function getCurrentPostId() {
-    if (!empty($this->args["post_id"])) {
-      return (int) $this->args["post_id"];
-    }
-    $post = get_post();
-    return $post ? (int) $post->ID : 0;
-  }
-
   protected function getItems() {
     $depth =
       $this->getField("mod_navigation_depth") ?:
@@ -157,7 +145,7 @@ class ModNavigation extends MxModule {
     if ($depth <= 0) {
       return null;
     }
-    $post = get_post($post_id ?? $this->getCurrentPostId());
+    $post = get_post($post_id ?? $this->getCurrentPost());
     if (!$post) {
       return [];
     }
@@ -240,7 +228,7 @@ class ModNavigation extends MxModule {
   }
 
   protected function getSiblings() {
-    $post = get_post($this->getCurrentPostId());
+    $post = $this->getCurrentPost();
     if (!$post) {
       return [];
     }

--- a/psr-4/Modularity/ModNavigation/ModNavigation.php
+++ b/psr-4/Modularity/ModNavigation/ModNavigation.php
@@ -121,6 +121,18 @@ class ModNavigation extends MxModule {
     return get_field($field, $this->ID, ...$args);
   }
 
+  /**
+   * Current page id: the constructor `post_id` arg (set in headless REST
+   * context), falling back to the global `$post`.
+   */
+  protected function getCurrentPostId() {
+    if (!empty($this->args["post_id"])) {
+      return (int) $this->args["post_id"];
+    }
+    $post = get_post();
+    return $post ? (int) $post->ID : 0;
+  }
+
   protected function getItems() {
     $depth =
       $this->getField("mod_navigation_depth") ?:
@@ -145,7 +157,7 @@ class ModNavigation extends MxModule {
     if ($depth <= 0) {
       return null;
     }
-    $post = get_post($post_id);
+    $post = get_post($post_id ?? $this->getCurrentPostId());
     if (!$post) {
       return [];
     }
@@ -228,7 +240,7 @@ class ModNavigation extends MxModule {
   }
 
   protected function getSiblings() {
-    $post = get_post();
+    $post = get_post($this->getCurrentPostId());
     if (!$post) {
       return [];
     }

--- a/psr-4/Modularity/MxModule.php
+++ b/psr-4/Modularity/MxModule.php
@@ -60,6 +60,23 @@ class MxModule extends \Modularity\Module {
   }
 
   /**
+   * The post this module is rendered in the context of.
+   * @return \WP_Post|null
+   */
+  protected function getCurrentPost() {
+    /**
+     * Filters the post a module is rendered in the context of.
+     *
+     * Defaults to the global `$post`, which is empty outside the loop
+     * (e.g. REST requests) — hook in to supply the page being rendered.
+     *
+     * @param \WP_Post|null $post   Context post.
+     * @param MxModule      $module Module instance.
+     */
+    return apply_filters("mx/module/current_post", get_post(), $this);
+  }
+
+  /**
    * Data array
    * @return array $data
    */


### PR DESCRIPTION
**Problem**
När navigationsmodulen används med källan children eller siblings och renderas headless via REST (t.ex. mu-api/v1/module/{id}?parent={id}) blir resultatet alltid tomt, trots att sidan har publicerade barnsidor.

Orsaken är att getChildren() och getSiblings() hämtar den aktuella sidan via den globala $post. Det fungerar i en vanlig Municipio-rendering, där modulen renderas inne i WordPress-loopen — men i ett REST-anrop finns ingen loop och därmed ingen global post. Uppslaget misslyckas tyst och modulen returnerar en tom lista.

Det intressanta är att modulen redan får rätt sidkontext: Modularity-moduler instansieras med ett post_id-argument som talar om vilken sida modulen renderas på, och REST-endpointen skickar med det. Modulen läste bara aldrig argumentet, utan gick direkt på den globala posten.

**Lösning**
En ny hjälpmetod getCurrentPostId() avgör vilken sida modulen renderas i kontexten av: i första hand $this->args['post_id'], och om det saknas den globala $post precis som tidigare. getChildren() och getSiblings() använder nu den metoden i stället för att förlita sig på den globala posten.

**Varför den här lösningen?**
Felet ligger i modulens eget kontrakt — den tar emot en sidkontext men ignorerar den. Då är rätt åtgärd att modulen börjar respektera sitt argument, inte att konsumenter arbetar runt det. Alternativen vore att i konsumerande projekt fejka en global $post i REST-anropet (global state-manipulation med svåröverskådliga sidoeffekter på filter och plugins), eller att duplicera modulens logik nedströms (kod som genast börjar divergera). Med fixen här fungerar modulen för alla headless-konsumenter av paketet, och beteendet vid vanlig rendering är oförändrat eftersom fallbacken till den globala posten finns kvar. Källorna menu och manual berörs inte alls.

**Verifierat**
mu-api/v1/module/{id}?parent={id} returnerar nu sidans barnsidor i data.items (tidigare alltid 0).
Vanlig rendering i Municipio fungerar som tidigare.